### PR TITLE
Add Drag and Drop and Share to Obsidian functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
 			"name": "obsidian-gospel-study",
 			"version": "1.0.0",
 			"license": "MIT",
+			"dependencies": {
+				"diff": "^5.2.0"
+			},
 			"devDependencies": {
+				"@types/diff": "^5.0.9",
 				"@types/jest": "^29.5.12",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
@@ -1730,6 +1734,12 @@
 				"@types/tern": "*"
 			}
 		},
+		"node_modules/@types/diff": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.0.9.tgz",
+			"integrity": "sha512-RWVEhh/zGXpAVF/ZChwNnv7r4rvqzJ7lYNSmZSVTxjV0PBLf6Qu7RNg+SUtkpzxmiNkjCx0Xn2tPp7FIkshJwQ==",
+			"dev": true
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -2705,6 +2715,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/diff": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+			"engines": {
+				"node": ">=0.3.1"
 			}
 		},
 		"node_modules/diff-sequences": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	},
 	"license": "MIT",
 	"devDependencies": {
+		"@types/diff": "^5.0.9",
 		"@types/jest": "^29.5.12",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
@@ -33,5 +34,8 @@
 		"tslib": "2.4.0",
 		"typescript": "4.7.4",
 		"yaml": "^2.4.1"
+	},
+	"dependencies": {
+		"diff": "^5.2.0"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,12 @@ import { Plugin, Editor } from "obsidian";
 import { GospelStudyPluginSettingTab } from "./gospelStudyPluginSettingTab";
 import { DEFAULT_SETTINGS, GospelStudyPluginSettings } from "./gospelStudyPluginSettings";
 import { getStudyBlockTextFromUrl } from "./getStudyBlockTextFromUrl";
+import { diffLines, Change } from "diff";
 
 export default class GospelStudyPlugin extends Plugin {
 	public settings!: GospelStudyPluginSettings;
+
+	handledByPasteEvent!: boolean;
 
 	/**
 	 * Loads the plugin settings from the data store.
@@ -29,8 +32,14 @@ export default class GospelStudyPlugin extends Plugin {
 
 		this.addSettingTab(new GospelStudyPluginSettingTab(this.app, this));
 
+		this.handledByPasteEvent = false;
+
 		this.registerEvent(
 			this.app.workspace.on("editor-paste", this.onEditorPaste.bind(this))
+		);
+
+		this.registerEvent(
+			this.app.workspace.on("editor-change", this.onEditorChange.bind(this))
 		);
 	}
 
@@ -106,6 +115,8 @@ export default class GospelStudyPlugin extends Plugin {
 
 		const blockText = await getStudyBlockTextFromUrl(clipboardData, this.settings);
 
+		this.handledByPasteEvent = true;
+
 		editor.replaceSelection(blockText);
 
 		if (this.settings.copyCurrentNoteLinkAfterPaste === true) {
@@ -113,4 +124,34 @@ export default class GospelStudyPlugin extends Plugin {
 		}
 	}
 
+	private async onEditorChange(editor: Editor, info: { data: string; }) {
+		if (this.handledByPasteEvent){ 
+			// ensure we don't try to handle the paste event again
+			this.handledByPasteEvent = false;
+			return;
+		}
+
+		console.log("editor changed");
+
+		const previousContent = info.data;
+		const currentContent = editor.getValue();
+
+		if (previousContent !== currentContent) {
+			const diff = diffLines(previousContent, currentContent);
+			const addedLines = diff.filter((part: Change) => part.added);
+
+			const urlPattern = "https://www.churchofjesuschrist.org/study/";
+			const addedUrlLine = addedLines.find((part: Change) => part.value.includes(urlPattern));
+
+			if (addedUrlLine) {
+				const blockText = await getStudyBlockTextFromUrl(addedUrlLine.value, this.settings);
+				editor.replaceSelection(blockText);
+
+				if (this.settings.copyCurrentNoteLinkAfterPaste === true) {
+					this.copyCurrentNoteLinkToClipboard();
+				}
+			}
+		}
+		this.handledByPasteEvent = false;
+	}
 }


### PR DESCRIPTION
Enable dragging and dropping study links and also using the "Share to Obsidian" option and iOS and Android.

This works by registering a method to the "editor-change" event. This method will search for any "unresolved" (raw) study urls and resolve them to their equivalent study block.