### PR TITLE
feat: add preview functionality for selected study block format

### DIFF
--- a/src/getStudyBlockTextFromUrl.ts
+++ b/src/getStudyBlockTextFromUrl.ts
@@ -4,6 +4,15 @@ import { standardizeSearchParams } from "./studyUrlFormatting";
 import { registeredUrlParsers } from "./urlParsers";
 
 export async function getStudyBlockTextFromUrl(data: string, pluginSettings: GospelStudyPluginSettings): Promise<string | null> {
+	const block = await getStudyBlockFromUrl(data, pluginSettings);
+	if (!block) {
+		return null;
+	}
+	const blockText = block.toString(pluginSettings.studyBlockFormat);
+	return blockText;
+}
+
+export async function getStudyBlockFromUrl(data: string, pluginSettings: GospelStudyPluginSettings): Promise<StudyBlock | null> {
 	const standardizedUrl = standardizeSearchParams(data);
 	const url = new URL(standardizedUrl);
 
@@ -16,7 +25,6 @@ export async function getStudyBlockTextFromUrl(data: string, pluginSettings: Gos
 	const urlParserResult = urlParser.parse(url);
 
 	const block = await StudyBlock.create(urlParserResult, pluginSettings);
-	const blockText = block.toString(pluginSettings.studyBlockFormat);
 
-	return blockText;
+	return block;
 }

--- a/src/gospelStudyPluginSettingTab.ts
+++ b/src/gospelStudyPluginSettingTab.ts
@@ -43,53 +43,33 @@ export class GospelStudyPluginSettingTab extends PluginSettingTab {
 				return dropdown;
 			});
 
-		// Create a div to render Markdown
-		const markdownDiv = containerEl.createDiv();
-		markdownDiv.addClass('markdown-rendered');
+		const studyBlockFormatPreviewDiv = containerEl.createDiv();
+		studyBlockFormatPreviewDiv.addClass('markdown-rendered');
 
-		// Render the Markdown content into the div
-		MarkdownRenderer.render(
-			this.app,
-			this.studyBlock?.toString(this.plugin.settings.studyBlockFormat) ?? "",
-			markdownDiv,
-			'',
-			this.plugin
-		);
+		this.renderBlockFormatPreview(studyBlockFormatPreviewDiv);
 
-		new Setting(containerEl)
-			.setName("Format String")
-			.setDesc("The format string used to generate the study block.")
-			.addTextArea((text) => {
-				text.setPlaceholder("Enter the format string")
-					.setValue(this.plugin.settings.studyBlockFormat)
-					.onChange(async (value) => {
-						this.plugin.settings.studyBlockFormat = value;
-						if (!this.formats.some(format => format === value)) {
-							this.plugin.settings.customStudyBlockFormat = value;
-						}
-						await this.plugin.saveSettings();
+		const formatStringTextArea = containerEl.createEl("textarea");
+		formatStringTextArea.style.width = "100%";
+		formatStringTextArea.style.height = "150px";
+		formatStringTextArea.style.resize = "none";
+		formatStringTextArea.value = this.plugin.settings.studyBlockFormat;
 
-						// Update the Markdown content
-						markdownDiv.empty();
-						MarkdownRenderer.render(
-							this.app,
-							this.studyBlock?.toString(this.plugin.settings.studyBlockFormat) ?? "",
-							markdownDiv,
-							'',
-							this.plugin
-						);
-					});
+		// on change, update the format string
+		formatStringTextArea.addEventListener("input", async (event) => {
+			const target = event.target as HTMLTextAreaElement;
+			this.plugin.settings.studyBlockFormat = target.value;
+			if (!this.formats.some(format => format === target.value)) {
+				this.plugin.settings.customStudyBlockFormat = target.value;
+			}
+			await this.plugin.saveSettings();
 
-				text.inputEl.style.width = "100%";
-				text.inputEl.style.height = "150px";
-				text.inputEl.style.resize = "none";
+			// Update the Markdown content
+			this.renderBlockFormatPreview(studyBlockFormatPreviewDiv);
+		});
 
-				text.inputEl.addEventListener("focusout", () => {
-					this.display();
-				});
-
-				return text;
-			});
+		formatStringTextArea.addEventListener("focusout", () => {
+			this.display();
+		});
 
 		new Setting(containerEl)
 			.setName("Copy Current Note Link After Paste")
@@ -129,5 +109,16 @@ export class GospelStudyPluginSettingTab extends PluginSettingTab {
 
 				return toggle;
 			});
+	}
+
+	private renderBlockFormatPreview(parentDiv: HTMLDivElement) {
+		parentDiv.empty();
+		MarkdownRenderer.render(
+			this.app,
+			this.studyBlock?.toString(this.plugin.settings.studyBlockFormat) ?? "",
+			parentDiv,
+			'',
+			this.plugin
+		);
 	}
 }

--- a/src/gospelStudyPluginSettingTab.ts
+++ b/src/gospelStudyPluginSettingTab.ts
@@ -1,15 +1,23 @@
 import { STUDY_BLOCK_FORMAT_1, STUDY_BLOCK_FORMAT_2 } from "./defaultPluginSettings";
 import GospelStudyPlugin from "./main";
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, MarkdownRenderer, PluginSettingTab, Setting } from "obsidian";
+import { StudyBlock } from "./studyBlock";
+import { getStudyBlockFromUrl } from "./getStudyBlockTextFromUrl";
 
 export class GospelStudyPluginSettingTab extends PluginSettingTab {
 	public plugin: GospelStudyPlugin;
 	formats: string[];
+	studyBlock!: StudyBlock | null;
 
 	public constructor(app: App, plugin: GospelStudyPlugin) {
 		super(app, plugin);
 		this.plugin = plugin;
 		this.formats = [STUDY_BLOCK_FORMAT_1, STUDY_BLOCK_FORMAT_2];
+
+	}
+
+	public async initSampleStudyBlockText() {
+		this.studyBlock = await getStudyBlockFromUrl("https://www.churchofjesuschrist.org/study/scriptures/nt/john/3?lang=eng&id=p16-p17#p16", this.plugin.settings);
 	}
 
 	public display(): void {
@@ -35,8 +43,21 @@ export class GospelStudyPluginSettingTab extends PluginSettingTab {
 				return dropdown;
 			});
 
+		// Create a div to render Markdown
+		const markdownDiv = containerEl.createDiv();
+		markdownDiv.addClass('markdown-rendered');
+
+		// Render the Markdown content into the div
+		MarkdownRenderer.render(
+			this.app,
+			this.studyBlock?.toString(this.plugin.settings.studyBlockFormat) ?? "",
+			markdownDiv,
+			'',
+			this.plugin
+		);
+
 		new Setting(containerEl)
-			.setName("Current Format String")
+			.setName("Format String")
 			.setDesc("The format string used to generate the study block.")
 			.addTextArea((text) => {
 				text.setPlaceholder("Enter the format string")
@@ -45,58 +66,68 @@ export class GospelStudyPluginSettingTab extends PluginSettingTab {
 						this.plugin.settings.studyBlockFormat = value;
 						if (!this.formats.some(format => format === value)) {
 							this.plugin.settings.customStudyBlockFormat = value;
-						} 
+						}
 						await this.plugin.saveSettings();
+
+						// Update the Markdown content
+						markdownDiv.empty();
+						MarkdownRenderer.render(
+							this.app,
+							this.studyBlock?.toString(this.plugin.settings.studyBlockFormat) ?? "",
+							markdownDiv,
+							'',
+							this.plugin
+						);
 					});
 
 				text.inputEl.style.width = "100%";
 				text.inputEl.style.height = "150px";
 				text.inputEl.style.resize = "none";
 
-                text.inputEl.addEventListener("focusout", () => {
-                    this.display();
-                });
+				text.inputEl.addEventListener("focusout", () => {
+					this.display();
+				});
 
 				return text;
 			});
 
 		new Setting(containerEl)
-		.setName("Copy Current Note Link After Paste")
-		.setDesc("Copy the current note link to the clipboard after pasting a study block.")
-		.addToggle((toggle) => {	
-			toggle.setValue(this.plugin.settings.copyCurrentNoteLinkAfterPaste)
-				.onChange(async (value) => {
-					this.plugin.settings.copyCurrentNoteLinkAfterPaste = value;
-					await this.plugin.saveSettings();
-				});
+			.setName("Copy Current Note Link After Paste")
+			.setDesc("Copy the current note link to the clipboard after pasting a study block.")
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.copyCurrentNoteLinkAfterPaste)
+					.onChange(async (value) => {
+						this.plugin.settings.copyCurrentNoteLinkAfterPaste = value;
+						await this.plugin.saveSettings();
+					});
 
-			return toggle;
-		});
-
-		new Setting(containerEl)
-		.setName("Retain Scripture Reference Links")
-		.setDesc('If enabled, scripture reference links (e.g.<a class="scripture-ref" href="https://www.churchofjesuschrist.org/study/scriptures/bofm/2-ne/21.12?lang=eng#p12">2&nbsp;Nephi 21:12</a>) will be retained, otherwise the hyperlink will be removed and only the text (e.g. "2 Nephi 21:12") will remain.')
-		.addToggle((toggle) => {	
-			toggle.setValue(this.plugin.settings.retainScriptureReferenceLinks)
-				.onChange(async (value) => {
-					this.plugin.settings.retainScriptureReferenceLinks = value;
-					await this.plugin.saveSettings();
-				});
-
-			return toggle;
-		});
+				return toggle;
+			});
 
 		new Setting(containerEl)
-		.setName("Retain Non-Breaking Spaces")
-		.setDesc('If enabled, non-breaking spaces (e.g. "&nbsp;") will be retained, otherwise they will be removed.')
-		.addToggle((toggle) => {	
-			toggle.setValue(this.plugin.settings.retainNonBreakingSpaces)
-				.onChange(async (value) => {
-					this.plugin.settings.retainNonBreakingSpaces = value;
-					await this.plugin.saveSettings();
-				});
+			.setName("Retain Scripture Reference Links")
+			.setDesc('If enabled, scripture reference links (e.g.<a class="scripture-ref" href="https://www.churchofjesuschrist.org/study/scriptures/bofm/2-ne/21.12?lang=eng#p12">2&nbsp;Nephi 21:12</a>) will be retained, otherwise the hyperlink will be removed and only the text (e.g. "2 Nephi 21:12") will remain.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.retainScriptureReferenceLinks)
+					.onChange(async (value) => {
+						this.plugin.settings.retainScriptureReferenceLinks = value;
+						await this.plugin.saveSettings();
+					});
 
-			return toggle;
-		});
+				return toggle;
+			});
+
+		new Setting(containerEl)
+			.setName("Retain Non-Breaking Spaces")
+			.setDesc('If enabled, non-breaking spaces (e.g. "&nbsp;") will be retained, otherwise they will be removed.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.retainNonBreakingSpaces)
+					.onChange(async (value) => {
+						this.plugin.settings.retainNonBreakingSpaces = value;
+						await this.plugin.saveSettings();
+					});
+
+				return toggle;
+			});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,10 @@ export default class GospelStudyPlugin extends Plugin {
 
 		await this.loadSettings();
 
-		this.addSettingTab(new GospelStudyPluginSettingTab(this.app, this));
+		const studyPluginTab = new GospelStudyPluginSettingTab(this.app, this);
+		await studyPluginTab.initSampleStudyBlockText();
+
+		this.addSettingTab(studyPluginTab);
 
 		this.registerEvent(
 			this.app.workspace.on("editor-paste", this.onEditorPaste.bind(this))


### PR DESCRIPTION
Added the ability to preview the selected format for study blocks. To help make this work, a new method to retrieve study blocks from a URL was added. The settings tab was also update to display a live preview as the format string is modified.

Fixes #60