### PR TITLE
feat: add retainParagraphMarker setting and formatter

### DIFF
--- a/src/defaultPluginSettings.ts
+++ b/src/defaultPluginSettings.ts
@@ -6,9 +6,10 @@ export const STUDY_BLOCK_FORMAT_2 = "> {{paragraphs:\n>\n> }}\n>\n> {{referenceL
 
 export const DEFAULT_SETTINGS: GospelStudyPluginSettings = {
 	studyBlockFormat: STUDY_BLOCK_FORMAT_1,
+	customStudyBlockFormat: "",
 	copyCurrentNoteLinkAfterPaste: true,
 	retainScriptureReferenceLinks: true,
 	retainNonBreakingSpaces: false,
-	customStudyBlockFormat: ""
+	retainParagraphMarkers: false
 };
 

--- a/src/gospelStudyPluginSettingTab.ts
+++ b/src/gospelStudyPluginSettingTab.ts
@@ -109,6 +109,19 @@ export class GospelStudyPluginSettingTab extends PluginSettingTab {
 
 				return toggle;
 			});
+
+		new Setting(containerEl)
+			.setName("Retain Paragraph Markers")
+			.setDesc('If enabled, paragraph markers ("¶") will be retained, otherwise they will be removed.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.retainParagraphMarkers)
+					.onChange(async (value) => {
+						this.plugin.settings.retainParagraphMarkers = value;
+						await this.plugin.saveSettings();
+					});
+
+				return toggle;
+			});
 	}
 
 	private renderBlockFormatPreview(parentDiv: HTMLDivElement) {

--- a/src/models/GospelStudyPluginSettings.ts
+++ b/src/models/GospelStudyPluginSettings.ts
@@ -4,4 +4,5 @@ export interface GospelStudyPluginSettings {
 	retainScriptureReferenceLinks: boolean;
     retainNonBreakingSpaces: boolean;
 	customStudyBlockFormat: string;
+    retainParagraphMarkers: boolean;
 }

--- a/src/paragraphFormatting/paragraphMarkerFormatter.ts
+++ b/src/paragraphFormatting/paragraphMarkerFormatter.ts
@@ -1,0 +1,26 @@
+import { GospelStudyPluginSettings } from "src/models/GospelStudyPluginSettings";
+import { ParagraphFormatter } from "src/models/ParagraphFormatter";
+
+/**
+ * A paragraph formatter that removes paragraph markers from the input paragraph acording to the settings.
+ */
+export const paragraphMarkerFormatter: ParagraphFormatter = {
+    isEnabled(settings: GospelStudyPluginSettings): boolean {
+        return !settings.retainParagraphMarkers;
+    },
+
+    format(paragraph: string): string {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(paragraph, 'text/html');
+
+        const paragraphMarkers = doc.querySelectorAll('.para-mark');
+
+        paragraphMarkers.forEach((element): void => {
+            element.remove();
+        });
+
+        paragraph = doc.body.innerHTML
+
+        return paragraph;
+    }
+};

--- a/src/paragraphFormatting/registeredFormatters.ts
+++ b/src/paragraphFormatting/registeredFormatters.ts
@@ -7,6 +7,7 @@ import { escapeSquareBracketsFormatter } from "./escapeSquareBracketsFormatter";
 import { breakRuleRemoveFormatter } from "./breakRuleRemoveFormatter";
 import { strongEmToMarkdownFormatter } from "./strongEmToMarkdownFormatter";
 import { nonBreakingSpaceFormatter } from "./nonBreakingSpaceFormatter";
+import { paragraphMarkerFormatter } from "./paragraphMarkerFormatter";
 
 export const registeredFormatters: ParagraphFormatter[] = [
     fullyQualifyStudyLinksFormatter,
@@ -16,5 +17,6 @@ export const registeredFormatters: ParagraphFormatter[] = [
     escapeSquareBracketsFormatter,
     breakRuleRemoveFormatter,
     strongEmToMarkdownFormatter,
-    nonBreakingSpaceFormatter
+    nonBreakingSpaceFormatter,
+    paragraphMarkerFormatter
 ]; 

--- a/test/paragraphFormatting/paragraphMarkerFormatter.test.ts
+++ b/test/paragraphFormatting/paragraphMarkerFormatter.test.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_SETTINGS } from "../../src/defaultPluginSettings";
+import { paragraphMarkerFormatter } from "../../src/paragraphFormatting/paragraphMarkerFormatter";
+import { GospelStudyPluginSettings } from "../../src/models/GospelStudyPluginSettings";
+
+describe('paragraphMarkerFormatter', () => {
+    describe('isEnabled', () => {
+        it('should return true if retainParagraphMarkers is false', () => {
+            const settings: GospelStudyPluginSettings = { ...DEFAULT_SETTINGS, retainParagraphMarkers: false };
+            expect(paragraphMarkerFormatter.isEnabled(settings)).toBe(true);
+        });
+
+        it('should return false if retainParagraphMarkers is true', () => {
+            const settings: GospelStudyPluginSettings = { ...DEFAULT_SETTINGS, retainParagraphMarkers: true };
+            expect(paragraphMarkerFormatter.isEnabled(settings)).toBe(false);
+        });
+    });
+
+    describe('format', () => {
+        it('should remove paragraph markers from the input paragraph', () => {
+            // Arrange
+            const inputParagraph = '<p>This is a paragraph.<span class="para-mark">¶</span></p>';
+
+            // Act
+            const result = paragraphMarkerFormatter.format(inputParagraph);
+
+            // Assert
+            const expectedOutput = '<p>This is a paragraph.</p>';
+            expect(result).toBe(expectedOutput);
+        });
+
+        it('should return the same paragraph if there are no paragraph markers', () => {
+            // Arrange
+            const inputParagraph = '<p>This is a paragraph.</p>';
+
+            // Act
+            const result = paragraphMarkerFormatter.format(inputParagraph)
+
+            // Assert
+            expect(result).toBe(inputParagraph);
+        });
+    });
+});


### PR DESCRIPTION
Introduce new setting to retain paragraph markers and implement the corresponding formatter. Update the settings tab to allow users to toggle this feature.